### PR TITLE
moving sidebar logic into one place

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -72,27 +72,6 @@ add_filter('comments_template', function ($comments_template) {
 });
 
 /**
- * The sage/display_sidebar filter can be used to define which conditions to enable the primary sidebar on.
- * https://github.com/roots/docs/blob/sage-9/sage/theme-sidebar.md#displaying-the-sidebar
- */
-add_filter( 'sage/display_sidebar', function ( $display ) {
-	static $display;
-
-	isset( $display ) || $display = in_array( true, [
-		// The sidebar will be displayed if any of the following return true
-		is_page(),
-		is_single(),
-        is_category(),
-        is_archive(),
-        is_search(),
-        is_404(),
-        is_home(),
-	] );
-
-	return $display;
-} );
-
-/**
  * allows oembed to occur from BCcampus' Kaltura instance
  */
 add_action( 'init', function () {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,11 +11,9 @@
             <main class="col-sm-8">
                 @yield('content')
             </main>
-            @if (App\display_sidebar())
                 <aside id="sidebar" class="col-sm-4">
                     @include('partials.sidebar')
                 </aside>
-            @endif
         </div>
     </div>
     @php(do_action('get_footer'))

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -14,6 +14,6 @@
   'item_spacing' => 'preserve',
   'walker'       => '',
   ] ); !!}
+@else
+  @php(dynamic_sidebar('sidebar-primary'))
 @endif
-
-@php(dynamic_sidebar('sidebar-primary'))


### PR DESCRIPTION
see https://github.com/BCcampus/bcc-sage/issues/50#issuecomment-337747846

The dynamic sidebar needs to show up on everything except pages. On pages, the menu list of pages needs to be the only thing on there. 

This puts the logic in one place instead of two and simplifies it with an either/or 