### PR TITLE
Slider

### DIFF
--- a/app/admin.php
+++ b/app/admin.php
@@ -28,3 +28,27 @@ add_action(
 		wp_enqueue_script( 'sage/customizer.js', asset_path( 'scripts/customizer.js' ), [ 'customize-preview' ], null, true );
 	}
 );
+
+/**
+ * Add customization settings for the theme
+ *
+ * @param \WP_Customize_Manager $wp_customize
+ */
+
+function customizerAddSetting( \WP_Customize_Manager $wp_customize ) {
+
+	$wp_customize->add_setting( 'slider_setting', [
+		'default'    => '',
+		'capability' => 'edit_theme_options',
+		'type'       => 'option'
+
+	] );
+
+	$wp_customize->add_control( 'slider_id', [
+		'label'    => __( 'Enter the slider ID', __NAMESPACE__ ),
+		'section'  => 'static_front_page',
+		'settings' => 'slider_setting'
+	] );
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\customizerAddSetting', 11 );

--- a/app/admin.php
+++ b/app/admin.php
@@ -30,17 +30,14 @@ add_action(
 );
 
 /**
- * Add customization settings for the theme
- *
- * @param \WP_Customize_Manager $wp_customize
+ *  Adds a slider ID setting in the customizer "Homepage Settings" section
  */
 
-function customizerAddSetting( \WP_Customize_Manager $wp_customize ) {
+add_action( 'customize_register', function ( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_setting( 'slider_setting', [
-		'default'    => '',
-		'capability' => 'edit_theme_options',
-		'type'       => 'option'
+		'default'    => '0',
+		'capability' => 'edit_theme_options'
 
 	] );
 
@@ -48,7 +45,6 @@ function customizerAddSetting( \WP_Customize_Manager $wp_customize ) {
 		'label'    => __( 'Enter the slider ID', __NAMESPACE__ ),
 		'section'  => 'static_front_page',
 		'settings' => 'slider_setting'
-	] );
-}
-
-add_action( 'customize_register', __NAMESPACE__ . '\customizerAddSetting', 11 );
+		] );
+	}
+);

--- a/app/controllers/FrontPage.php
+++ b/app/controllers/FrontPage.php
@@ -19,4 +19,9 @@ class FrontPage extends Controller {
 
 		return $latest;
 	}
+
+	public function getSliderId() {
+		$slider = get_theme_mod('slider_setting');
+		return $slider;
+	}
 }

--- a/app/controllers/FrontPage.php
+++ b/app/controllers/FrontPage.php
@@ -20,8 +20,16 @@ class FrontPage extends Controller {
 		return $latest;
 	}
 
+	/**
+	 * Returns the short-code with the slider ID attribute the user set in the customizer menu
+	 * Works with Smart Slider 3 plugin
+	 * @return string
+	 */
 	public function getSliderId() {
-		$slider = get_theme_mod('slider_setting');
+		$id = get_theme_mod( 'slider_setting', 0 );
+
+		$slider = do_shortcode( '[smartslider3 slider=' . $id . ']' );
+
 		return $slider;
 	}
 }

--- a/resources/assets/styles/components/_carousel.scss
+++ b/resources/assets/styles/components/_carousel.scss
@@ -4,3 +4,7 @@
 		line-height: 2em;
 	}
 }
+
+.n2-ss-control-bullet {
+	 justify-content: flex-end !important;
+ }

--- a/resources/assets/styles/main.scss
+++ b/resources/assets/styles/main.scss
@@ -23,7 +23,7 @@
 @import "components/nav";
 @import "components/uio";
 @import "components/wp-classes";
-@import "components/_carousel";
+@import "components/carousel";
 @import "layouts/header";
 @import "layouts/sidebar";
 @import "layouts/footer";

--- a/resources/views/front-page.blade.php
+++ b/resources/views/front-page.blade.php
@@ -2,7 +2,10 @@
 
 @section('content')
 	<span itemscope itemtype="http://schema.org/ItemPage">
-	  <div class="row">
+	  <div class="container-fluid">
+		  {!! do_shortcode('[smartslider3 slider=4]') !!}
+	  </div>
+		<div class="row">
 	  <div class="col-4">
 	  @include('partials.children-top')
 		  @include('partials.children-projects')

--- a/resources/views/front-page.blade.php
+++ b/resources/views/front-page.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 	<span itemscope itemtype="http://schema.org/ItemPage">
 	  <div class="container-fluid">
-		  {!! do_shortcode('[smartslider3 slider=4]') !!}
+		  {!! $get_slider_id !!}
 	  </div>
 		<div class="row">
 	  <div class="col-4">

--- a/resources/views/front-page.blade.php
+++ b/resources/views/front-page.blade.php
@@ -2,9 +2,6 @@
 
 @section('content')
 	<span itemscope itemtype="http://schema.org/ItemPage">
-	  <div class="container-fluid">
-		  {!! $get_slider_id !!}
-	  </div>
 		<div class="row">
 	  <div class="col-4">
 	  @include('partials.children-top')

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -24,4 +24,9 @@
 			</div>
 		</nav>
 	</div>
+	@if (is_front_page())
+		<div class="container-fluid slider">
+			{!! $get_slider_id !!}
+		</div>
+	@endif
 </header>


### PR DESCRIPTION
Completes #149, using the "Smart Slider 3" plugin, and adding an option to the customizer home page settings to enter the ID of the slider, this generates the shortcode to display the slider on the homepage. Import the following zip to Smart Slider 3 [Home.ss3.zip](https://github.com/BCcampus/bcc-sage/files/2289239/Home.ss3.zip) to get the settings/styling/content for the slider. 

![slider](https://user-images.githubusercontent.com/17072191/44132349-ee5d353c-a00d-11e8-8f77-a4dba00b8cd0.png)


