### PR TITLE
add full width layout, apply phpcs, fix news template

### DIFF
--- a/app/admin.php
+++ b/app/admin.php
@@ -33,18 +33,23 @@ add_action(
  *  Adds a slider ID setting in the customizer "Homepage Settings" section
  */
 
-add_action( 'customize_register', function ( \WP_Customize_Manager $wp_customize ) {
+add_action(
+	'customize_register', function ( \WP_Customize_Manager $wp_customize ) {
 
-	$wp_customize->add_setting( 'slider_setting', [
-		'default'    => '0',
-		'capability' => 'edit_theme_options'
+		$wp_customize->add_setting(
+			'slider_setting', [
+				'default'    => '0',
+				'capability' => 'edit_theme_options',
 
-	] );
+			]
+		);
 
-	$wp_customize->add_control( 'slider_id', [
-		'label'    => __( 'Enter the slider ID', __NAMESPACE__ ),
-		'section'  => 'static_front_page',
-		'settings' => 'slider_setting'
-		] );
+		$wp_customize->add_control(
+			'slider_id', [
+				'label'    => __( 'Enter the slider ID', __NAMESPACE__ ),
+				'section'  => 'static_front_page',
+				'settings' => 'slider_setting',
+			]
+		);
 	}
 );

--- a/resources/views/404.blade.php
+++ b/resources/views/404.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.app')
 
 @section('content')
-  @include('partials.page-header')
 
   @if (!have_posts())
     <div class="alert alert-warning">

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.app')
 
 @section('content')
-  @include('partials.page-header')
 
   @if (!have_posts())
     <div class="alert alert-warning">

--- a/resources/views/layouts/full.blade.php
+++ b/resources/views/layouts/full.blade.php
@@ -1,0 +1,23 @@
+<!doctype html>
+<html @php(language_attributes())>
+@include('partials.head')
+<body @php(body_class())>
+@include('partials.microdata-open')
+@include('partials.uio')
+@php(do_action('get_header'))
+    @include('partials.header')
+    <div class="wrap container-fluid" role="document">
+		@include('partials.page-header')
+		<div class="content row">
+            <main class="col-sm-12">
+                @yield('content')
+            </main>
+        </div>
+    </div>
+    @php(do_action('get_footer'))
+        @include('partials.footer')
+        @php(wp_footer())
+@include('partials.uio-script')
+@include('partials.microdata-close')
+</body>
+</html>

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -3,7 +3,6 @@
 @section('content')
   @while(have_posts()) @php(the_post())
   <span itemscope itemtype="http://schema.org/ItemPage">
-  @include('partials.page-header')
     @include('partials.content-page')
   </span>
   @endwhile

--- a/resources/views/partials/children-projects.blade.php
+++ b/resources/views/partials/children-projects.blade.php
@@ -2,10 +2,10 @@
 	<h4>Projects</h4>
 	@foreach($get_children_of_page as $child)
 		<article class="col-sm project d-flex">
-				<a class="p-2" href="{{$child->guid}}"><?php echo get_the_post_thumbnail( $child->ID );?></a>
+				<a class="p-2" href="{{$child->guid}}"><?php echo get_the_post_thumbnail( $child->ID ); ?></a>
 				<div class="p-2">
 					<h5><a href="{{$child->guid}}">{{$child->post_title}}</a></h5>
-					<p><?php echo wp_trim_words( $child->post_content, '30', "<a href='{$child->guid}'>&hellip;</a>" );?></p>
+					<p><?php echo wp_trim_words( $child->post_content, '30', "<a href='{$child->guid}'>&hellip;</a>" ); ?></p>
 				</div>
 		</article>
 	@endforeach

--- a/resources/views/partials/tag-open-ed.blade.php
+++ b/resources/views/partials/tag-open-ed.blade.php
@@ -1,17 +1,17 @@
 <article class="tag-open-ed">
 	<h4>Open Education</h4>
-	<section class="row articles">
+	<section class="articles">
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 	</section>
 </article>

--- a/resources/views/partials/tag-open-textbooks.blade.php
+++ b/resources/views/partials/tag-open-textbooks.blade.php
@@ -1,17 +1,17 @@
 <article class="tag-open-textbooks">
 	<h4>Open Textbooks</h4>
-	<section class="row articles">
+	<section class="articles">
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 		<article class="col-sm">
-			Placeholder
+			<p>Placeholder</p>
 		</article>
 	</section>
 </article>

--- a/resources/views/template-news.blade.php
+++ b/resources/views/template-news.blade.php
@@ -2,7 +2,7 @@
   Template Name: News Landing Template
 --}}
 
-@extends('layouts.app')
+@extends('layouts.full')
 
 @section('content')
 	@while(have_posts()) @php(the_post())


### PR DESCRIPTION
this PR adds a full width layout template for landing pages that need it (i.e. news landing template) It also resolves a double header image on single pages/posts and applies coding standards.