### PR TITLE
change link to guid for events

### DIFF
--- a/resources/views/partials/events-feature.blade.php
+++ b/resources/views/partials/events-feature.blade.php
@@ -21,16 +21,11 @@ $args = [
 	</header>
 	<div class="d-flex flex-row flex-wrap mb-2 no-gutters">
 	@foreach(\App\App::getLatestNews( $args ) as $recent )
-		<?php
-		// not using $child->guid since guid does not
-		// update to current domain when importing content
-		$link = site_url() . '/' . $recent->post_name;
-		?>
 		<article class="col no-gutters px-md-1">
 			<div class="featured-event col d-flex" style="background-image: url({{\App\App::getThumbUrl($recent->ID)}});">
 				<h4 class="purple-bkgd col mt-auto">
 					<time itemprop="datePublished" class="updated upper" datetime="{{ get_post_time('c', true, $recent->ID) }}">{{ get_the_date('',$recent->ID) }}</time>
-					<br><a class="text-inverse" href="{{$link}}">{{$recent->post_title}}</a></h4>
+					<br><a class="text-inverse" href="{{ $recent->guid }}">{{ $recent->post_title }}</a></h4>
 			</div>
 		</article>
 	@endforeach

--- a/resources/views/partials/events-related.blade.php
+++ b/resources/views/partials/events-related.blade.php
@@ -7,15 +7,9 @@ $limit = 4;
 </h3>
 <section class="relevant d-flex flex-row flex-wrap">
 	@foreach(\App\App::getRelevant($post, $post_types, $limit, $tag) as $related_post )
-		<?php
-		// not using $child->guid since guid does not
-		// update to current domain when importing content
-		$link = site_url() . '/' . $related_post->post_name;
-
-		;?>
 		<article class="col border py-2 m-md-2" itemscope itemtype="http://schema.org/Article">
 			<p class="upper"><time itemprop="datePublished" class="updated" datetime="{{ get_post_time('c', true, $related_post->ID) }}">{{ get_the_date('',$related_post->ID) }}</time></p>
-			<h4><a class="purple" href="{{$link}}">{{$related_post->post_title}}</a></h4>
+			<h4><a class="purple" href="{{ $related_post->guid }}">{{ $related_post->post_title }}</a></h4>
 		</article>
 	@endforeach
 </section>

--- a/resources/views/partials/events-upcoming.blade.php
+++ b/resources/views/partials/events-upcoming.blade.php
@@ -17,18 +17,13 @@ $args = [
 	<h4>Upcoming</h4>
 	</header>
 	@foreach(\App\App::getLatestNews( $args ) as $recent )
-		<?php
-		// not using $child->guid since guid does not
-		// update to current domain when importing content
-		$link = site_url() . '/' . $recent->post_name;
-		?>
 		<article class="events-upcoming my-1 border" itemscope itemtype="http://schema.org/Article">
 			<div class="row pad-left">
 				<div class="col-sm-2 events-image-box" style="background-image: url({{\App\App::getThumbUrl($recent->ID)}});">
 				</div>
 				<div class="col-sm-10">
 					<p class="upper"><time itemprop="datePublished" class="updated" datetime="{{ get_post_time('c', true, $recent->ID) }}">{{ get_the_date('',$recent->ID) }}</time></p>
-					<h4><a class="purple" href="{{$link}}">{{$recent->post_title}}</a></h4>
+					<h4><a class="purple" href="{{ $recent->guid }}">{{ $recent->post_title }}</a></h4>
 				</div>
 			</div>
 		</article>


### PR DESCRIPTION
event links currently break because they aren't built the same way as post links and we don't have to be concerned that events will be migrated in from another instance. 

This will now use the guid for event links. 