### PR TITLE
prefer a sort order of most recent, fix php warnings

### DIFF
--- a/app/controllers/App.php
+++ b/app/controllers/App.php
@@ -135,6 +135,8 @@ class App extends Controller {
 			'post_type'           => $type,
 			'post_status'         => 'publish',
 			'category_name'       => $category_name,
+			'orderby'             => 'date',
+			'order'               => 'DESC',
 		];
 
 		$maybe_more_args = array_merge( $args, $append_t );

--- a/resources/views/partials/events-related.blade.php
+++ b/resources/views/partials/events-related.blade.php
@@ -1,13 +1,14 @@
 @php
 	$post_types = [ 'ai1ec_event' ];
 	$limit = 4;
+	$category_name = '';
 @endphp
 <div class="container-fluid my-3">
 <h3>Related Events <img class="mx-2 mb-1" src="@asset('images/green-dots.png')" alt="decorative green dots">
 	<small><a href="{{get_site_url()}}/events">view all events</a></small>
 </h3>
 <section class="related-events d-flex flex-row flex-wrap">
-	@foreach(\App\App::getRelevant($post, $post_types, $limit, $tag) as $related_post )
+	@foreach(\App\App::getRelevant($post, $post_types, $limit, $category_name) as $related_post )
 		<article class="col-md-3 my-2" itemscope itemtype="http://schema.org/Event">
 			<div class="border p-3 min-height-sm">
 			<p class="text-uppercase font-size-sm"><time itemprop="startDate" datetime="{{ get_post_time('c', true, $related_post->ID) }}">{{ get_the_date('',$related_post->ID) }}</time></p>

--- a/resources/views/partials/news-related.blade.php
+++ b/resources/views/partials/news-related.blade.php
@@ -2,6 +2,7 @@
 $post_types = [ 'post', 'page' ];
 $limit = 3;
 $i = 0;
+$category_name = '';
 @endphp
 <div class="flex-row shady-bkgd">
 	<div class="shady-bkgd py-3 container-fluid">
@@ -9,7 +10,7 @@ $i = 0;
 			<small><a href="{{get_site_url()}}/news">view all news</a></small>
 		</h3>
 		<section class="related-news d-flex flex-row flex-wrap">
-			@foreach(\App\App::getRelevant($post, $post_types, $limit, $tag) as $related_post )
+			@foreach(\App\App::getRelevant($post, $post_types, $limit, $category_name) as $related_post )
 				@php
 				$link = \App\App::maybeGuid( $related_post->ID, $related_post->post_name );
 


### PR DESCRIPTION
addresses https://github.com/BCcampus/bcc-sage/issues/309 short of removing events, it prefers more recent events with a specified sort order (based on date). The goal of the `getRelated()` function is to return a fixed number of posts related to the existing post and if there are no related events in the future, a graceful degradation is to present related events in the past. Fixing the sort order gives preference to most recent events while still being able to deliver on requirement of a fixed number of related events. 